### PR TITLE
chore: update Node to 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    
+
 jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
@@ -13,20 +13,20 @@ jobs:
     - run: |
         npm install
         npm run all
-        
+
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-          
+
     - uses: ./
-      with: 
+      with:
         path: 'test-results/nunit.xml'
         report-title: 'nunit'
         access-token: ${{secrets.GITHUB_TOKEN}}
 
     - uses: ./
-      with: 
+      with:
         path: 'test-results/not-executed.trx'
         reportType: 'trx'
         report-title: 'trx-not-executed'
@@ -41,7 +41,7 @@ jobs:
         fetch-depth: 0
 
     - name: Release
-      uses: cycjimmy/semantic-release-action@v2
+      uses: cycjimmy/semantic-release-action@v3
       id: semantic-release
       with:
         extra_plugins: |

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: "Test Report"
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'check'  


### PR DESCRIPTION
HXCE-376

Bumps the now-obsolete Node 12 to 16 so that the action won't break when GitHub removes support for Node 12 in Summer 2023 (see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).